### PR TITLE
Initial deploy

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -1,0 +1,15 @@
+server {
+    listen 80;
+
+    server_name api.acemonstertoys.org;
+
+    location / {
+        proxy_pass http://localhost:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
+}
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '2'
+services:
+        # Start the standard MongoDB container
+        mongodb:
+                container_name: "mongodb"
+                image: mongo:latest
+                environment:
+                        - MONGO_DATA_DIR=/data/db
+                        - MONGO_LOG_DIR=/dev/log
+                # persist the data on the host rather than in the container
+                # this makes the container disposable without losing the data
+                volumes:
+                        - ./data:/data/db
+                # forward the standard mongoDB port
+                ports:
+                        - "27017:27017"
+                # start mongodb
+                command: mongod --smallfiles
+        web:
+                container_name: "amt-api"
+                build: .
+                restart: always
+                # link the API to the mongoDB container
+                links:
+                        - mongodb:mongodb
+                # we need that container
+                depends_on:
+                        - mongodb
+                # forward the web port to the server's port
+                ports:
+                        - "3000:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,14 @@
 version: '2'
 services:
+        # Start nginx
+        nginx:
+                image: nginx:latest
+                ports:
+                        - "8080:80"
+                volumes:
+                        - ./default.conf:/etc/nginx/conf.d/defaut.conf
+                links:
+                        - app
         # Start the standard MongoDB container
         mongodb:
                 container_name: "mongodb"
@@ -16,7 +25,7 @@ services:
                         - "27017:27017"
                 # start mongodb
                 command: mongod --smallfiles
-        web:
+        app:
                 container_name: "amt-api"
                 build: .
                 restart: always

--- a/server_setup.md
+++ b/server_setup.md
@@ -1,0 +1,9 @@
+# How to get this thing deployed on a fresh server
+
+1. Install docker on the server, start docker daemon (https://www.digitalocean.com/community/tutorials/how-to-install-and-use-docker-on-centos-7)
+2. Make sure that docker daemon is running!!!
+3. Install docker-compose on the server (https://docs.docker.com/compose/install/#install-compose)
+4. Make a directory for the project
+5. In new directory, make a file called `docker-compose.yml`
+6. Grab the latest version of the `docker-compose.yml` file from this git repo, and paste the contents into the server's new `docker-compose.yml` file
+7. Run the following: `sudo docker-compose up`

--- a/server_setup.md
+++ b/server_setup.md
@@ -6,4 +6,7 @@
 4. Make a directory for the project
 5. In new directory, make a file called `docker-compose.yml`
 6. Grab the latest version of the `docker-compose.yml` file from this git repo, and paste the contents into the server's new `docker-compose.yml` file
-7. Run the following: `sudo docker-compose up`
+7. Copy the nginx configuration from this repo to the folder on the remote
+8. Run the following: `sudo docker-compose up`. Note that this can be run with the `-d` flag to run it detached (in background) so that you can keep doing stuff with your user account.
+
+For the above, it may be easier to just clone this repo to the remote.


### PR DESCRIPTION
Add initial deployment information and scripts.

This requires action from someone who can modify the `acemonstertoys.org` DNS records to point `api.acemonstertoys.org` to the prgmr server. I probably don't have permission, and I certainly don't have the knowledge of how to do that within the existing AMT infrastructure.